### PR TITLE
Fix doc comment typo in db module

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,4 @@
-//! Database connection helerrorpers.
+//! Database connection helpers.
 //!
 //! This module provides a small wrapper around the Diesel connection pool and
 //! utilities to establish a connection to the SQLite database used in the


### PR DESCRIPTION
## Summary
- fix typo in `src/db.rs` module docs

## Testing
- `cargo test --all-features`

------
https://chatgpt.com/codex/tasks/task_e_687d58d14e84832f9c4cc30c980eca44