### PR TITLE
Improve documentation and traits for shared models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # pushkind-common
+
+Shared utilities and models for Pushkind services.

--- a/src/domain/benchmark.rs
+++ b/src/domain/benchmark.rs
@@ -1,7 +1,11 @@
 use chrono::NaiveDateTime;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize)]
+/// A benchmark reference product used for price comparisons.
+///
+/// This domain struct mirrors the `benchmarks` table and is
+/// independent from any persistence layer representation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Benchmark {
     pub id: i32,
     pub hub_id: i32,
@@ -18,6 +22,11 @@ pub struct Benchmark {
     pub processing: bool,
 }
 
+/// Data required to insert a new [`Benchmark`].
+///
+/// This struct is typically deserialized from incoming requests
+/// before being converted into a database model.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NewBenchmark {
     pub hub_id: i32,
     pub name: String,

--- a/src/domain/crawler.rs
+++ b/src/domain/crawler.rs
@@ -1,7 +1,8 @@
 use chrono::NaiveDateTime;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize)]
+/// Metadata about a crawler job and its progress.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Crawler {
     pub id: i32,
     pub hub_id: i32,

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,3 +1,8 @@
+//! Domain models shared between services.
+//!
+//! These data structures intentionally avoid any database or
+//! framework-specific details so they can be reused across crates.
+
 #[cfg(feature = "dantes")]
 pub mod benchmark;
 #[cfg(feature = "dantes")]

--- a/src/domain/product.rs
+++ b/src/domain/product.rs
@@ -1,7 +1,8 @@
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize)]
+/// A product extracted from a crawler run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Product {
     pub id: i32,
     pub crawler_id: i32,
@@ -18,6 +19,7 @@ pub struct Product {
     pub embedding: Option<Vec<u8>>,
 }
 
+/// Information required to create a new [`Product`].
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct NewProduct {
     pub crawler_id: i32,

--- a/src/models/benchmark.rs
+++ b/src/models/benchmark.rs
@@ -3,6 +3,7 @@ use diesel::prelude::*;
 
 use crate::domain::benchmark::{Benchmark as DomainBenchmark, NewBenchmark as DomainNewBenchmark};
 
+/// Diesel model representing a row in the `benchmarks` table.
 #[derive(Debug, Clone, Identifiable, Queryable)]
 #[diesel(table_name = crate::schema::dantes::benchmarks)]
 pub struct Benchmark {
@@ -21,6 +22,7 @@ pub struct Benchmark {
     pub processing: bool,
 }
 
+/// Insertable form of [`Benchmark`] used for creating new rows.
 #[derive(Insertable)]
 #[diesel(table_name = crate::schema::dantes::benchmarks)]
 pub struct NewBenchmark<'a> {

--- a/src/models/crawler.rs
+++ b/src/models/crawler.rs
@@ -3,6 +3,7 @@ use diesel::prelude::*;
 
 use crate::domain::crawler::Crawler as DomainCrawler;
 
+/// Diesel representation of a crawler row.
 #[derive(Debug, Clone, Identifiable, Queryable)]
 #[diesel(table_name = crate::schema::dantes::crawlers)]
 pub struct Crawler {

--- a/src/models/product.rs
+++ b/src/models/product.rs
@@ -3,6 +3,7 @@ use diesel::prelude::*;
 
 use crate::domain::product::{NewProduct as DomainNewProduct, Product as DomainProduct};
 
+/// Diesel model representing the `products` table.
 #[derive(Debug, Clone, Identifiable, Queryable, QueryableByName)]
 #[diesel(table_name = crate::schema::dantes::products)]
 #[diesel(foreign_derive)]
@@ -22,6 +23,7 @@ pub struct Product {
     pub embedding: Option<Vec<u8>>,
 }
 
+/// Insertable/patchable form of [`Product`].
 #[derive(Debug, Insertable, AsChangeset)]
 #[diesel(table_name = crate::schema::dantes::products)]
 pub struct NewProduct {

--- a/src/repository/errors.rs
+++ b/src/repository/errors.rs
@@ -1,7 +1,14 @@
+//! Error types used by repository implementations.
+//!
+//! These errors provide a consistent abstraction over Diesel and
+//! connection-pool errors so callers can react without depending on the
+//! underlying database layer.
+
 use diesel::r2d2::{Error as R2D2Error, PoolError};
 use diesel::result::{DatabaseErrorKind, Error as DieselError};
 use thiserror::Error;
 
+/// Errors that can occur while interacting with the persistence layer.
 #[derive(Debug, Error)]
 pub enum RepositoryError {
     #[error("Entity not found")]
@@ -23,6 +30,7 @@ pub enum RepositoryError {
     Unexpected(String),
 }
 
+/// Convenient alias for results returned by repository functions.
 pub type RepositoryResult<T> = Result<T, RepositoryError>;
 
 impl From<DieselError> for RepositoryError {

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -1,1 +1,6 @@
+//! Helpers for implementing data repositories.
+//!
+//! This module collects error types and other utilities used by repository
+//! implementations throughout the project.
+
 pub mod errors;

--- a/src/zmq.rs
+++ b/src/zmq.rs
@@ -1,5 +1,9 @@
 use serde::Serialize;
 
+/// Serialize `msg` and send it to `zmq_address` using a ZMQ `PUSH` socket.
+///
+/// A new socket is created for each call. Any serialization or socket errors
+/// are bubbled up to the caller.
 pub fn send_zmq_message<T: Serialize>(
     msg: &T,
     zmq_address: &str,
@@ -11,7 +15,7 @@ pub fn send_zmq_message<T: Serialize>(
     let serialized = serde_json::to_vec(msg)?;
     requester.send(&serialized, 0)?;
 
-    log::info!("Sent message {} bytes to {}", serialized.len(), zmq_address);
+    log::info!("Sent {} bytes to {}", serialized.len(), zmq_address);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add missing serde derives and doc comments for domain models
- document repository utilities and error types
- describe ZeroMQ sender and simplify log output

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689b4287d824832a98040fb649d756c7