### PR TITLE
fix: keep ZMQ context alive for sender thread

### DIFF
--- a/src/zmq.rs
+++ b/src/zmq.rs
@@ -104,6 +104,8 @@ impl ZmqSender {
         let warmup_ms = opts.warmup_ms;
 
         thread::spawn(move || {
+            // Keep the context alive for the socket's lifetime.
+            let _ctx = ctx;
             if warmup_ms > 0 {
                 thread::sleep(Duration::from_millis(warmup_ms));
             }


### PR DESCRIPTION
## Summary
- keep `zmq::Context` alive in sender thread to prevent premature termination

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --tests -- -Dwarnings`
- `cargo build --all-features --verbose`
- `cargo test --all-features --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68b70123dac4832a84613a90f1720478