### PR TITLE
Add next parameter redirect middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ thiserror = { version = "2.0.16", optional = true }
 serde_json = { version = "1.0.143", optional = true }
 tera = { version = "1.20.0", features = ["builtins"], optional = true }
 tokio = { version = "1.47.1", features = ["sync"], optional = true }
+url = "2.5.7"

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -28,7 +28,7 @@ async fn redirects_unauthorized_to_signin() {
     assert_eq!(resp.status(), StatusCode::SEE_OTHER);
     assert_eq!(
         resp.headers().get(header::LOCATION).unwrap(),
-        "http://auth.test.me/"
+        "http://auth.test.me/?next=http%3A%2F%2Flocalhost%3A8080%2F"
     );
 }
 


### PR DESCRIPTION
## Summary
- Capture full request URL in `RedirectUnauthorizedMiddleware`
- Append `next` query param to auth redirect using `url` crate
- Update tests for new redirect behavior
- Depend on `url` crate

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --tests -- -Dwarnings`
- `cargo build --all-features --verbose`
- `cargo test --all-features --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68bae0e16278832aa60f1c304625182f