### PR TITLE
Add next parameter redirect middleware

### DIFF
--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -33,6 +33,31 @@ async fn redirects_unauthorized_to_signin() {
 }
 
 #[actix_web::test]
+async fn redirects_unauthorized_to_relative_signin() {
+    let server_config = CommonServerConfig {
+        secret: "secret".to_string(),
+        auth_service_url: "/auth/signin".to_string(),
+    };
+
+    let app = test::init_service(
+        App::new()
+            .wrap(RedirectUnauthorized)
+            .app_data(web::Data::new(server_config.clone()))
+            .default_service(web::to(|| async { HttpResponse::Unauthorized().finish() })),
+    )
+    .await;
+
+    let req = test::TestRequest::default().to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        resp.headers().get(header::LOCATION).unwrap(),
+        "/auth/signin?next=http%3A%2F%2Flocalhost%3A8080%2F"
+    );
+}
+
+#[actix_web::test]
 async fn success_response_passes_through() {
     let server_config = CommonServerConfig {
         secret: "secret".to_string(),


### PR DESCRIPTION
## Summary
- Capture full request URL in `RedirectUnauthorizedMiddleware`
- Append `next` query param to auth redirect using `url` crate
- Update tests for new redirect behavior
- Depend on `url` crate
- Support relative `auth_service_url` values in auth redirect middleware

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --tests -- -Dwarnings`
- `cargo build --all-features --verbose`
- `cargo test --all-features --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68bae53d0e5c832aafaea8623cf6905f