### PR TITLE
Handle fragments in relative auth redirect URLs

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -106,11 +106,18 @@ where
                         .append_pair("next", &incoming_url)
                         .finish();
 
-                    if auth_service_url.contains('?') {
-                        format!("{}&{}", auth_service_url, encoded_next)
-                    } else {
-                        format!("{}?{}", auth_service_url, encoded_next)
+                    let (base, fragment) = auth_service_url
+                        .split_once('#')
+                        .map(|(b, f)| (b, Some(f)))
+                        .unwrap_or_else(|| (auth_service_url.as_str(), None));
+
+                    let separator = if base.contains('?') { '&' } else { '?' };
+                    let mut redirect = format!("{base}{separator}{encoded_next}");
+                    if let Some(fragment) = fragment {
+                        redirect.push('#');
+                        redirect.push_str(fragment);
                     }
+                    redirect
                 };
 
                 let redirect_response = HttpResponse::SeeOther()

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -58,6 +58,31 @@ async fn redirects_unauthorized_to_relative_signin() {
 }
 
 #[actix_web::test]
+async fn redirects_unauthorized_to_relative_signin_with_fragment() {
+    let server_config = CommonServerConfig {
+        secret: "secret".to_string(),
+        auth_service_url: "/auth/signin#step2".to_string(),
+    };
+
+    let app = test::init_service(
+        App::new()
+            .wrap(RedirectUnauthorized)
+            .app_data(web::Data::new(server_config.clone()))
+            .default_service(web::to(|| async { HttpResponse::Unauthorized().finish() })),
+    )
+    .await;
+
+    let req = test::TestRequest::default().to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        resp.headers().get(header::LOCATION).unwrap(),
+        "/auth/signin?next=http%3A%2F%2Flocalhost%3A8080%2F#step2",
+    );
+}
+
+#[actix_web::test]
 async fn success_response_passes_through() {
     let server_config = CommonServerConfig {
         secret: "secret".to_string(),


### PR DESCRIPTION
## Summary
- place `next` query parameter before any fragment on relative auth URLs
- cover fragment scenario with regression test

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --tests -- -Dwarnings`
- `cargo build --all-features --verbose`
- `cargo test --all-features --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68baeea62604832a8057d35d8a0d230d